### PR TITLE
Inline SVG as URI encoded string, instead base64

### DIFF
--- a/lib/rails-sass-images/sass/inline.rb
+++ b/lib/rails-sass-images/sass/inline.rb
@@ -1,3 +1,4 @@
+require 'cgi'
 require 'mime-types'
 
 module RailsSassImages::Sass
@@ -14,8 +15,15 @@ module RailsSassImages::Sass
 
     mime = MIME::Types.type_for(asset.to_s).first.content_type
     file = asset.read
-    file = [file].flatten.pack('m').gsub("\n", '')
 
-    Sass::Script::String.new("url('data:#{mime};base64,#{file}')")
+    if mime == 'image/svg+xml'
+      file     = CGI::escape(file).gsub('+', '%20')
+      encoding = 'charset=utf-8'
+    else
+      file     = [file].flatten.pack('m').gsub("\n", '')
+      encoding = 'base64'
+    end
+
+    Sass::Script::String.new("url('data:#{mime};#{encoding},#{file}')")
   end
 end

--- a/spec/app/app/assets/images/square.svg
+++ b/spec/app/app/assets/images/square.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"><path d="M0,0h1v1H0" fill="#ff0000"/></svg>

--- a/spec/app/app/assets/stylesheets/inline-svg.sass
+++ b/spec/app/app/assets/stylesheets/inline-svg.sass
@@ -1,0 +1,2 @@
+.icon
+  background: inline("square.svg")

--- a/spec/plain_spec.rb
+++ b/spec/plain_spec.rb
@@ -73,6 +73,7 @@ describe RailsSassImages do
 
     it "inlines assets" do
       expect(@assets['inline.css'].to_s).to eq ".icon{background:#{INLINE}}\n"
+      expect(@assets['inline-svg.css'].to_s).to eq ".icon{background:#{INLINE_SVG}}\n"
     end
 
     it "gets image size" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,9 @@ require_relative '../lib/rails-sass-images'
 
 require 'rspec/rails'
 
-DIR    = Pathname(__FILE__).dirname
-INLINE = 'url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAGCAAAAADB' +
-         'UmCpAAAAC0lEQVQI12NgwAcAAB4AAW6FRzIAAAAASUVORK5CYII=")'
+DIR        = Pathname(__FILE__).dirname
+INLINE     = 'url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAGCAAAAADB' +
+             'UmCpAAAAC0lEQVQI12NgwAcAAB4AAW6FRzIAAAAASUVORK5CYII=")'
+INLINE_SVG = 'url("data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2F' +
+             'www.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%201%201%22%3E%3Cpath' +
+             '%20d%3D%22M0%2C0h1v1H0%22%20fill%3D%22%23ff0000%22%2F%3E%3C%2Fsvg%3E%0A")'


### PR DESCRIPTION
Add support for inlining SVG via URI encode, instead base64.